### PR TITLE
Fix #7: made the refresh button work in settings page

### DIFF
--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -52,7 +52,13 @@ function SettingsPage() {
   const handleClick = async (type) => {
     if (type === "Currency") {
       setIsCurrencyModalOpen(true);
-    } else if (type === "Logout") {
+    } 
+
+    // A simple functionality to refresh the settings page on a button click
+    else if(type === "Refresh"){
+      window.location.reload();
+    }
+    else if (type === "Logout") {
       try {
         await logout();
         navigate("/");


### PR DESCRIPTION
This PR fixes issue #7 by implementing the refresh button functionality in the settings page.

Changes:
- Added functionality to the refresh button in SettingsPage.jsx
- Implemented page reload when the refresh button is clicked

Testing done:
- Verified that clicking the refresh button reloads the settings page.